### PR TITLE
交差点だけで”地価”を算出するよう変更

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tigtag"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies.bevy]

--- a/src/game_play/map.rs
+++ b/src/game_play/map.rs
@@ -80,7 +80,6 @@ type WithMapEntities = Or< ( With<SpriteWall>, With<SpriteDot> ) >;
 //スプライトをspawnしてマップを表示する
 pub fn spawn_sprite
 (   q1: Query<Entity, WithMapEntities>,
-    q2: Query<( &mut Text, &TextUiNumTile )>,
     mut map: ResMut<Map>,
     mut cmds: Commands,
     asset_svr: Res<AssetServer>,

--- a/src/game_play/map.rs
+++ b/src/game_play/map.rs
@@ -126,54 +126,6 @@ pub fn spawn_sprite
             }
         }
     }
-
-    //マス目の重みづけ用の値を算出する
-    map.fill_land_values( q2 );
-}
-
-impl Map
-{   //中心の座標をもらい、周囲9マスのドットを数える
-    pub fn count_9squares( &self, center: Grid ) -> i32
-    {   let mut count = 0;
-        for dx in -1..=1
-        {   for dy in -1..=1
-            {   let grid = center + Grid::new( dx, dy );
-                if self.is_passage( grid ) && self.o_entity( grid ).is_some()
-                {   count += 1;
-                }
-            }
-        }
-        count
-    }
-
-    //マス目の重みづけ用の値を算出する
-    fn fill_land_values( &mut self, mut _q: Query<( &mut Text, &TextUiNumTile )> )
-    {   for y in MAP_GRIDS_RANGE_Y
-        {   for x in MAP_GRIDS_RANGE_X
-            {   let grid = Grid::new( x, y );
-                *self.land_values_mut( grid )
-                    = if self.is_passage( grid )
-                    {   self.count_9squares( grid )
-                    }
-                    else
-                    {   0
-                    };
-            }
-        }
-
-        //デバッグ用の表示
-        #[cfg( debug_assertions )]
-        _q.for_each_mut
-        (   | ( mut text, TextUiNumTile( grid ) ) |
-            text.sections[ 0 ].value
-                = if self.is_passage( *grid )
-                {   self.land_values( *grid ).to_string()
-                }
-                else
-                {   "".to_string()
-                }
-        );
-    }
 }
 
 //End of code.

--- a/src/game_play/player.rs
+++ b/src/game_play/player.rs
@@ -222,33 +222,6 @@ pub fn scoring_and_clear_stage
                 let _ = state.overwrite_set( next );
                 ev_clear.send( EventClear );    //後続の処理にクリアを伝える
             }
-            else
-            {   //クリアではないなら周囲9マスのland_valuesを更新する
-                for dx in -1..=1
-                {   for dy in -1..=1
-                    {   let grid = player.grid + Grid::new( dx, dy );
-                        *map.land_values_mut( grid ) =
-                        {   if map.is_passage( grid ) && map.o_entity( grid ).is_some()
-                            {   map.count_9squares( grid )
-                            }
-                            else
-                            {   0
-                            }
-                        };
-
-                        //デバッグ用の表示
-                        #[cfg( debug_assertions )]
-                        _q2.for_each_mut
-                        (   | ( mut text, TextUiNumTile( x ) ) |
-                            if *x == grid
-                            {   let count = map.land_values( grid );
-                                text.sections[ 0 ].value
-                                    = if count != 0 { count.to_string() } else { "".to_string() }
-                            }
-                        );
-                    }
-                }
-            }
         }
     }
 }

--- a/src/game_play/player.rs
+++ b/src/game_play/player.rs
@@ -60,7 +60,7 @@ pub fn move_sprite
     map: Res<Map>,
     state: ResMut<State<GameState>>,
     ( mut ev_clear, mut ev_over ): ( EventReader<EventClear>, EventReader<EventOver> ),
-    ( cmds, inkey, time ): ( Commands, Res<Input<KeyCode>>, Res<Time> ),
+    ( inkey, time ): ( Res<Input<KeyCode>>, Res<Time> ),
 )
 {   //直前の判定でクリア／オーバーしていたらスプライトの表示を変更しない
     if ev_clear.iter().next().is_some() { return }
@@ -106,7 +106,7 @@ pub fn move_sprite
                     sides[ 0 ],
                 Ordering::Greater => //三叉路または十字路
                     if let Some ( fnx ) = player.fn_runaway
-                    {   fnx( &player, q_chasers, map, &sides, state, cmds ) //外部関数で進行方向を決める
+                    {   fnx( &player, q_chasers, map, &sides ) //外部関数で進行方向を決める
                     }
                     else
                     {   let mut rng = rand::thread_rng();

--- a/src/game_play/player/demo_algorithm.rs
+++ b/src/game_play/player/demo_algorithm.rs
@@ -8,8 +8,6 @@ pub fn which_way_player_goes
     q_chasers: Query<&Chaser>,
     map: Res<Map>,
     sides: &[ DxDy ],
-    mut _state: ResMut<State<GameState>>,
-    mut _cmds: Commands,
 ) -> DxDy
 {   let mut rng = rand::thread_rng();
 
@@ -49,7 +47,7 @@ pub fn which_way_player_goes
     let mut risk_none   = Vec::with_capacity( 3 ); //最大で十字路(3)
     for side in sides
     {   let byway = player.next + side;
-        let risk = check_risk( byway, player, &goals, &map, &mut _cmds );
+        let risk = check_risk( byway, player, &goals, &map );
         if risk.is_none()
         {   risk_none.push ( ( side, map.land_values( byway ) ) );
         }
@@ -57,10 +55,6 @@ pub fn which_way_player_goes
         {   risk_rating.push ( ( side, risk ) );
         }
     }
-
-    //devモードで交差点でpauseする仕掛け
-    // #[cfg( debug_assertions )]
-    // let _ = _state.push( GameState::Pause );
 
     if risk_none.is_empty()
     {   //リスク値が低い(値が大きい)順にソートして最大値を求める
@@ -103,7 +97,6 @@ fn check_risk
     player: &Player,
     goals: &[ Grid ],
     map: &Res<Map>,
-    _cmds: &mut Commands,
 ) -> Option<usize>
 {   let mut target    = byway;       //脇道の入口の座標
     let mut previous  = player.next; //戻り路の座標
@@ -168,19 +161,6 @@ fn check_risk
             //一歩進む
             previous = target;
             target   = byway;
-
-            //devモードで経路探索の様子を表示する仕組み
-            // #[cfg( debug_assertions )]
-            // {   let color = COLOR_SPRITE_DEBUG_GRID;
-            //     let custom_size = Some ( Pixel::new( PIXELS_PER_GRID, PIXELS_PER_GRID ) * 0.8 );
-            //     let pixel = previous.into_pixel_map();
-            //     _cmds
-            //     .spawn_bundle( SpriteBundle::default() )
-            //     .insert( Sprite { color, custom_size, ..default() } )
-            //     .insert( Transform::from_translation( pixel.extend( 100.0 ) ) )
-            //     .insert( PathFinder )
-            //     ;
-            // }
         }
         //loop end
 

--- a/src/game_play/player/demo_algorithm.rs
+++ b/src/game_play/player/demo_algorithm.rs
@@ -80,6 +80,23 @@ pub fn which_way_player_goes
     }
 }
 
+impl Map
+{   //指定した座標とその四方のドットを数える(結果は0～4)
+    fn land_values( &self, center: Grid ) -> i32
+    {   //指定の座標にドットはあるか
+        let mut count = if self.o_entity( center ).is_some() { 1 } else { 0 };
+
+        //四方にドットはあるか
+        for side in self.get_byways_list( center )
+        {   if self.o_entity( center + side ).is_some()
+            {   count += 1;
+            }
+        }
+
+        count
+    }
+}
+
 //リスクを評価する
 fn check_risk
 (   byway: Grid,

--- a/src/public/types/map.rs
+++ b/src/public/types/map.rs
@@ -21,7 +21,6 @@ pub struct Map
 {   pub rng            : rand::prelude::StdRng,     //マップ生成専用の乱数生成器(マップに再現性を持たせるため)
     map_bits           : Vec<Vec<usize>>,           //マップの各グリッドの状態をbitで保存
     dot_entities       : Vec<Vec<Option<Entity>>>,  //ドットをdespawnする際に使うEntityIDを保存
-    land_values        : Vec<Vec<i32>>,             //マス目(通路のドット)の重みづけ用
     pub remaining_dots : i32,                       //マップに残っているドットの数
     dummy_o_entity_none: Option<Entity>,            //o_entity_mut()の範囲外アクセスで&mut Noneを返すために使用
 }
@@ -41,7 +40,6 @@ impl Default for Map
         {   rng                : StdRng::seed_from_u64( seed ),
             map_bits           : vec![ vec![ 0   ; MAP_GRIDS_HEIGHT as usize ]; MAP_GRIDS_WIDTH as usize ],
             dot_entities       : vec![ vec![ None; MAP_GRIDS_HEIGHT as usize ]; MAP_GRIDS_WIDTH as usize ],
-            land_values        : vec![ vec![ 0   ; MAP_GRIDS_HEIGHT as usize ]; MAP_GRIDS_WIDTH as usize ],
             remaining_dots     : 0,
             dummy_o_entity_none: None,
         }
@@ -117,9 +115,6 @@ impl Map
         }
         else { &mut self.dummy_o_entity_none } //範囲外は&mut Option::Noneを返す
     }
-
-    pub fn land_values    ( &    self, grid: Grid ) ->      i32 {      self.land_values[ grid.x as usize ][ grid.y as usize ] }
-    pub fn land_values_mut( &mut self, grid: Grid ) -> &mut i32 { &mut self.land_values[ grid.x as usize ][ grid.y as usize ] }
 }
 
 //End of code.

--- a/src/public/types/player_chaser.rs
+++ b/src/public/types/player_chaser.rs
@@ -32,7 +32,7 @@ impl Default for Player
 }
 
 //関数ポインタ型((demoplay)自機の移動方向を決める関数)
-type FnRunAway = fn( &Player, Query<&Chaser>, Res<Map>, &[ DxDy ], ResMut<State<GameState>>, Commands ) -> DxDy;
+type FnRunAway = fn( &Player, Query<&Chaser>, Res<Map>, &[ DxDy ] ) -> DxDy;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/target/tigtag.js
+++ b/target/tigtag.js
@@ -1716,48 +1716,48 @@ function getImports() {
         const ret = wasm.memory;
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2040 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 928, __wbg_adapter_34);
+    imports.wbg.__wbindgen_closure_wrapper2039 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 935, __wbg_adapter_34);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2826 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 1265, __wbg_adapter_37);
+    imports.wbg.__wbindgen_closure_wrapper2825 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 1272, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2828 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 1265, __wbg_adapter_37);
+    imports.wbg.__wbindgen_closure_wrapper2827 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 1272, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2830 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 1265, __wbg_adapter_37);
+    imports.wbg.__wbindgen_closure_wrapper2829 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 1272, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2832 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 1265, __wbg_adapter_37);
+    imports.wbg.__wbindgen_closure_wrapper2831 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 1272, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2834 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 1265, __wbg_adapter_37);
+    imports.wbg.__wbindgen_closure_wrapper2833 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 1272, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2836 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 1265, __wbg_adapter_37);
+    imports.wbg.__wbindgen_closure_wrapper2835 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 1272, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2838 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 1265, __wbg_adapter_50);
+    imports.wbg.__wbindgen_closure_wrapper2837 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 1272, __wbg_adapter_50);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2840 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 1265, __wbg_adapter_37);
+    imports.wbg.__wbindgen_closure_wrapper2839 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 1272, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2842 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 1265, __wbg_adapter_37);
+    imports.wbg.__wbindgen_closure_wrapper2841 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 1272, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper28260 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 15109, __wbg_adapter_57);
+    imports.wbg.__wbindgen_closure_wrapper28259 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 15116, __wbg_adapter_57);
         return addHeapObject(ret);
     };
 


### PR DESCRIPTION
　マップ全体に”地価”を設定していたため、特にWASM環境において、自機がドットのあるマスを進行する場合にFPSが下がってしまった。  
　この現象を解消するためマップ全体の”地価”を廃止し、自機が交差点に入った場合のみ”地価”を計算するよう変更した。