### PR TITLE
WASM版がAndroid Chromeで正しく動作しない不具合の暫定回避

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tigtag"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies.bevy]

--- a/src/init_app.rs
+++ b/src/init_app.rs
@@ -17,7 +17,7 @@ impl Plugin for InitApp
             width    : SCREEN_PIXELS_WIDTH,
             height   : SCREEN_PIXELS_HEIGHT,
             resizable: false,
-            fit_canvas_to_parent: true,
+            // fit_canvas_to_parent: true, //FIX v0.6.1: Android Chromeで発生する不具合を回避
             ..default()
         };
         app

--- a/target/tigtag.js
+++ b/target/tigtag.js
@@ -219,11 +219,11 @@ function __wbg_adapter_34(arg0, arg1) {
 }
 
 function __wbg_adapter_37(arg0, arg1) {
-    wasm._dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__he4cf2587d6589cf1(arg0, arg1);
+    wasm._dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h0b19bc4a83276c73(arg0, arg1);
 }
 
 function __wbg_adapter_40(arg0, arg1, arg2) {
-    wasm._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h09d496645a233963(arg0, arg1, addHeapObject(arg2));
+    wasm._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h0ebc73e6fee9bd53(arg0, arg1, addHeapObject(arg2));
 }
 
 function __wbg_adapter_57(arg0, arg1, arg2) {
@@ -1716,48 +1716,48 @@ function getImports() {
         const ret = wasm.memory;
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper2162 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 1062, __wbg_adapter_34);
+    imports.wbg.__wbindgen_closure_wrapper2161 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 1061, __wbg_adapter_34);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3366 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3365 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 1624, __wbg_adapter_37);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3368 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3367 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 1624, __wbg_adapter_40);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3370 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3369 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 1624, __wbg_adapter_40);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3372 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3371 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 1624, __wbg_adapter_40);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3374 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3373 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 1624, __wbg_adapter_40);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3376 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3375 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 1624, __wbg_adapter_40);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3378 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3377 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 1624, __wbg_adapter_40);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3380 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3379 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 1624, __wbg_adapter_40);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper3382 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper3381 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 1624, __wbg_adapter_40);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_closure_wrapper40961 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 26247, __wbg_adapter_57);
+    imports.wbg.__wbindgen_closure_wrapper40941 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 26235, __wbg_adapter_57);
         return addHeapObject(ret);
     };
 


### PR DESCRIPTION
FIX #14 

- これまで`WindowDescriptor`の`fit_canvas_to_parent`に`true`を設定していた。
しかしこのままだとAndroid ChromeでWASM版が正しく動作しなかった。(Android Firefoxでは問題なし)
  - 同設定は自動的にブラウザのCanvasにセンタリングするための設定。設定しなくてもゲームに支障がない。
  - 同じ機能を実現するサードパーティー製プラグイン`bevy-web-resizer v4.0.1`でも同じ現象が発生した。
- 根治は難しいと判断し、センタリングしないことにした。(暫定回避)
